### PR TITLE
결과 복사시 이모지가 깨지는 현상 수정 + a

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,5 @@
 <svelte:head>
-  <title>{title}</title>
+  <title>Chuldle</title>
 </svelte:head>
 
 <style global lang="postcss">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -234,7 +234,7 @@
 	const GRAY_BOX = '⬜';
 
 	function generateSummary() {
-		let summary = `https://chuldle.netlify.app/`;
+		let summary = `Chuldle 결과\nhttps://chuldle.netlify.app/`;
 		if(practiceMode){
 			summary += `\nPractice\nAnswer: ${solution}\n`;
 		}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,3 +1,7 @@
+<svelte:head>
+  <title>{title}</title>
+</svelte:head>
+
 <style global lang="postcss">
 	@tailwind base;
 	@tailwind components;


### PR DESCRIPTION
## 1. 결과 복사시 이모지가 깨지는 현상 수정 

```
https://chuldle.netlify.app/Chuldle%20#260%E2%AC%9C%E2%AC%9C%F0%9F%9F%A9%F0%9F%9F%A9%E2%AC%9C%F0%9F%9F%A9%F0%9F%9F%A9%F0%9F%9F%A9%F0%9F%9F%A9%F0%9F%9F%A9%F0%9F%9F%A9%F0%9F%9F%A9
```

PC에서 문제를 맞춘 후 결과를 복사하면 위처럼 색상 이모지가 깨지는 현상이 발생했습니다. 기존 코드의 경우 `summury` 변수의 구성이 `URL + 회차 + 결과(이모지)`로 되어있어 `https://`가 맨 앞에 오게 됩니다. 이로 인해, 클립보드에 복사되는 과정에서 `회차와 결과`까지 모두 URL로 인식하고 인코딩을 한 것 같습니다. 

```js
let summary = `https://chuldle.netlify.app/`;
let summary = `Chuldle 결과\nhttps://chuldle.netlify.app/`;
```
08a338222c0fb6fc1c389621b6becad6489c4c84 커밋에서 기존 URL로 먼저 시작하던 구성 앞에 문자열을 추가해보았고, 그 결과 PC에서 결과를 복사해도 회차와 결과가 URL로 인코딩되지 않게 되었습니다. 

```
Chuldle 결과
https://chuldle.netlify.app/
Chuldle #260
⬜⬜🟩🟩⬜🟩
🟩🟩🟩🟩🟩🟩
```

굳이 `Chuldle 결과\n`이 아니라도 앞에 문자열을 넣어서 회차와 결과가 같이 인코딩 되지 않게 해주시면 좋을 것 같습니다.

## 2. Title 수정
기존 타이틀은 Svelt app이였으나 이를 **Chuldle**로 수정했습니다.

철들 재미있게 플레이하고 있습니다. 
재미난 웹사이트 만들어주셔서 감사합니다.
좋은 하루 되세요.